### PR TITLE
Add security.md file to the repo

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security
+
+If you believe you have found a new security vulnerability in this repository, please report it to us as follows.
+
+## Reporting Security Issues
+
+* Please do **not** report security vulnerabilities through public GitHub issues.
+
+* Please create a draft security advisory on the Github page: the reporting form is under `> Security > Advisories`. The URL is https://github.com/exasol/parquet-io-java/security/advisories/new.
+
+* If you prefer to email, please send your report to `infosec@exasol.com`.
+
+## Guidelines 
+
+* When reporting a vulnerability, please include as much information as possible, including the complete steps to reproduce the issue. 
+
+* Avoid sending us executables.
+
+* Feel free to include any script you wrote and used but avoid sending us scripts that download and run binaries. 
+
+* We will prioritise reports that show how the exploits work in realistic environments. 
+
+* We prefer all communications to be in English. 
+
+* We do not offer financial rewards. We are happy to acknowledge your research publicly when possible. 
+


### PR DESCRIPTION
This file explains how to report security vulnerabilities privately to Exasol.